### PR TITLE
More lexer performance

### DIFF
--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -40,6 +40,18 @@ module TinyGQL
       assert_equal [:IDENTIFIER, "lol"], lexer.next_token
     end
 
+    def test_int
+      str = "1"
+      lexer = Lexer.new str
+      assert_equal [:INT, "1"], lexer.next_token
+    end
+
+    def test_float
+      str = "1.2"
+      lexer = Lexer.new str
+      assert_equal [:FLOAT, "1.2"], lexer.next_token
+    end
+
     def test_block_string
       doc = <<-eos
 """


### PR DESCRIPTION
* Always skip IGNORE, make the regexp 0 or more
* Check eos? last so it doesn't happen on every token
* Default case can be UNKNOWN_CHAR since it's the catch-all anyway
* Combine keyword lexing into identifier lexing and make it hash lookup
* Combine integer and float lexing, since floats are always a suffix

Before:

```
       user     system      total        real
   1.488609   0.015946   1.504555 (  1.505386)
```

After:

```
          user     system      total        real
   1.136149   0.002111   1.138260 (  1.138285)
```