### PR TITLE
Add null visitors

### DIFF
--- a/lib/tinygql/visitors.rb.erb
+++ b/lib/tinygql/visitors.rb.erb
@@ -30,5 +30,19 @@ module TinyGQL
       end
 <% end %>
     end
+
+    module Null
+<% nodes.each do |node| %>
+      def handle_<%= node.human_name %> obj
+      end
+<% end %>
+    end
+
+    module NullFold
+<% nodes.each do |node| %>
+      def handle_<%= node.human_name %> obj, _
+      end
+<% end %>
+    end
   end
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -165,6 +165,54 @@ eod
       assert_equal 1, node.arguments.length
     end
 
+    def test_null
+      doc = <<-eod
+mutation {
+  a: likeStory(storyID: 12345) {
+    b: story {
+      c: likeCount
+    }
+  }
+}
+eod
+      viz = Module.new do
+        extend TinyGQL::Visitors::Null
+
+        def self.handle_field obj
+          true
+        end
+      end
+      parser = Parser.new doc
+      ast = parser.parse
+      ast.each { |node|
+        assert_equal(node.field?, !!node.accept(viz))
+      }
+    end
+
+    def test_null_fold
+      doc = <<-eod
+mutation {
+  a: likeStory(storyID: 12345) {
+    b: story {
+      c: likeCount
+    }
+  }
+}
+eod
+      viz = Module.new do
+        extend TinyGQL::Visitors::NullFold
+
+        def self.handle_field obj, x
+          x
+        end
+      end
+      parser = Parser.new doc
+      ast = parser.parse
+      ast.each { |node|
+        assert_equal(node.field?, !!node.fold(viz, true))
+      }
+    end
+
     def test_multiple_implements
       doc = <<-eod
 type SomeType implements a, b, c {


### PR DESCRIPTION
If you only care about one node type, and don't want to recursively walk the tree, Null visitors are for you.

For example, lets walk all nodes and only print field names but never use an `if` statement or an `is_a?` check:

```ruby
module Printer
  extend TinyGQL::Visitors::Null

  def self.handle_field obj
    puts obj.name
  end
end

ast = TinyGQL.parse DATA.read
ast.each do |node|
  node.accept Printer
end

__END__
mutation {
  a: likeStory(storyID: 12345) {
    b: story {
      c: likeCount
    }
  }
}
```

Want to do the same trick, but pass some context to the handler function?  Use the `NullFold` module:

```ruby
module Printer
  extend TinyGQL::Visitors::NullFold

  def self.handle_field obj, i
    puts "NODE ID: #{i}, NAME: #{obj.name}"
  end
end

ast = TinyGQL.parse DATA.read
ast.each_with_index do |node, i|
  node.fold Printer, i
end

__END__
mutation {
  a: likeStory(storyID: 12345) {
    b: story {
      c: likeCount
    }
  }
}
```