### PR TITLE
Use our lookup table to find special leads

### DIFF
--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -21,7 +21,7 @@ module TinyGQL
         lexer = Lexer.new punc
         token = lexer.next_token
         expected = PUNC_LUT[punc]
-        assert_equal(expected || [:ON, "on"], token)
+        assert_equal(expected, token)
       end
     end
 


### PR DESCRIPTION
Integer comparison is cheaper than doing `@scan.skip`.  Since we're looking up the byte anyway, we may as well check what tokens could possibly start with that byte, then whittle down our choices.

This really speeds up the JIT:

```
[aaron@tc-lan-adapter💪 ~/g/tinygql (main)]$ ruby --jit -w -I lib bin/bench.rb
Warming up --------------------------------------
        kitchen-sink     1.634k i/100ms
           negotiate    43.000  i/100ms
Calculating -------------------------------------
        kitchen-sink     16.921k (± 1.9%) i/s -     84.968k in   5.023524s
           negotiate    437.851  (± 1.8%) i/s -      2.193k in   5.010391s
        kitchen-sink       235
           negotiate      7365
[aaron@tc-lan-adapter💪 ~/g/tinygql (main)]$ git checkout -
Switched to branch 'faster-scanner'
[aaron@tc-lan-adapter💪 ~/g/tinygql (faster-scanner)]$ ruby --jit -w -I lib bin/bench.rb
Warming up --------------------------------------
        kitchen-sink     1.768k i/100ms
           negotiate    53.000  i/100ms
Calculating -------------------------------------
        kitchen-sink     18.098k (± 0.7%) i/s -     91.936k in   5.080180s
           negotiate    532.766  (± 0.9%) i/s -      2.703k in   5.073904s
        kitchen-sink       235
           negotiate      7365
```

Somewhat speeds up interpreter:

```
[aaron@tc-lan-adapter💪 ~/g/tinygql (main)]$ ruby -w -I lib bin/bench.rb
Warming up --------------------------------------
        kitchen-sink   889.000  i/100ms
           negotiate    23.000  i/100ms
Calculating -------------------------------------
        kitchen-sink      8.980k (± 0.6%) i/s -     45.339k in   5.048995s
           negotiate    234.836  (± 1.3%) i/s -      1.196k in   5.093903s
        kitchen-sink       235
           negotiate      7365
[aaron@tc-lan-adapter💪 ~/g/tinygql (main)]$ git checkout -
Switched to branch 'faster-scanner'
[aaron@tc-lan-adapter💪 ~/g/tinygql (faster-scanner)]$ ruby -w -I lib bin/bench.rb
Warming up --------------------------------------
        kitchen-sink   896.000  i/100ms
           negotiate    24.000  i/100ms
Calculating -------------------------------------
        kitchen-sink      9.059k (± 0.5%) i/s -     45.696k in   5.044164s
           negotiate    248.049  (± 2.0%) i/s -      1.248k in   5.033217s
        kitchen-sink       235
           negotiate      7365
```