### PR TITLE
Add a superclass to operation nodes and fragment nodes

### DIFF
--- a/lib/tinygql/nodes.yml
+++ b/lib/tinygql/nodes.yml
@@ -4,7 +4,10 @@ nodes:
     fields:
       - definitions: list
 
+  - name: ExecutableDefinition
+
   - name: OperationDefinition
+    parent: ExecutableDefinition
     fields:
     - type: literal
     - name?: literal
@@ -102,6 +105,7 @@ nodes:
       - directives?: list
 
   - name: FragmentDefinition
+    parent: ExecutableDefinition
     fields:
       - fragment_name: literal
       - type_condition


### PR DESCRIPTION
This will make it easier to validate that queries only contain executable operations (section 5.1.1 in the GraphQL spec)

For example we can do `raise unless ast.definitions.all?(&:executable_definition?)`